### PR TITLE
#139 Deliver exercise detail API shell and stub workspace payload

### DIFF
--- a/src/main/java/com/example/gittrainer/scenario/api/ScenarioCatalogController.java
+++ b/src/main/java/com/example/gittrainer/scenario/api/ScenarioCatalogController.java
@@ -2,11 +2,15 @@ package com.example.gittrainer.scenario.api;
 
 import com.example.gittrainer.scenario.application.BrowseScenarioCatalogUseCase;
 import com.example.gittrainer.scenario.domain.CatalogBrowseQuery;
+import com.example.gittrainer.scenario.application.LoadScenarioDetailUseCase;
+import com.example.gittrainer.scenario.application.ScenarioDetailNotFoundException;
+import com.example.gittrainer.scenario.domain.ScenarioDetailQuery;
 import com.example.gittrainer.scenario.infrastructure.ScenarioCatalogSourceUnavailableException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,13 +23,19 @@ public class ScenarioCatalogController {
 
     private final BrowseScenarioCatalogUseCase browseScenarioCatalogUseCase;
     private final ScenarioCatalogResponseMapper scenarioCatalogResponseMapper;
+    private final LoadScenarioDetailUseCase loadScenarioDetailUseCase;
+    private final ScenarioDetailResponseMapper scenarioDetailResponseMapper;
 
     public ScenarioCatalogController(
             BrowseScenarioCatalogUseCase browseScenarioCatalogUseCase,
-            ScenarioCatalogResponseMapper scenarioCatalogResponseMapper
+            ScenarioCatalogResponseMapper scenarioCatalogResponseMapper,
+            LoadScenarioDetailUseCase loadScenarioDetailUseCase,
+            ScenarioDetailResponseMapper scenarioDetailResponseMapper
     ) {
         this.browseScenarioCatalogUseCase = browseScenarioCatalogUseCase;
         this.scenarioCatalogResponseMapper = scenarioCatalogResponseMapper;
+        this.loadScenarioDetailUseCase = loadScenarioDetailUseCase;
+        this.scenarioDetailResponseMapper = scenarioDetailResponseMapper;
     }
 
     @GetMapping
@@ -39,8 +49,23 @@ public class ScenarioCatalogController {
         return scenarioCatalogResponseMapper.toResponse(browseScenarioCatalogUseCase.browse(query));
     }
 
+    @GetMapping("/{slug}")
+    public ScenarioDetailResponse loadScenarioDetail(
+            @PathVariable String slug,
+            @RequestParam(required = false) String source
+    ) {
+        return scenarioDetailResponseMapper.toResponse(
+                loadScenarioDetailUseCase.load(new ScenarioDetailQuery(slug, source))
+        );
+    }
+
     @ExceptionHandler(ScenarioCatalogSourceUnavailableException.class)
     ProblemDetail handleUnavailableSource(ScenarioCatalogSourceUnavailableException exception) {
         return ProblemDetail.forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE, exception.getMessage());
+    }
+
+    @ExceptionHandler(ScenarioDetailNotFoundException.class)
+    ProblemDetail handleMissingScenarioDetail(ScenarioDetailNotFoundException exception) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, exception.getMessage());
     }
 }

--- a/src/main/java/com/example/gittrainer/scenario/api/ScenarioDetailResponse.java
+++ b/src/main/java/com/example/gittrainer/scenario/api/ScenarioDetailResponse.java
@@ -1,0 +1,76 @@
+package com.example.gittrainer.scenario.api;
+
+import java.util.List;
+
+public record ScenarioDetailResponse(
+        String id,
+        String slug,
+        String title,
+        String summary,
+        String difficulty,
+        List<String> tags,
+        ScenarioDetailMetaResponse meta,
+        ScenarioWorkspaceResponse workspace
+) {
+}
+
+record ScenarioDetailMetaResponse(
+        String source,
+        boolean stub
+) {
+}
+
+record ScenarioWorkspaceResponse(
+        ScenarioWorkspaceShellResponse shell,
+        ScenarioTaskPreviewResponse task,
+        ScenarioRepositoryContextResponse repositoryContext
+) {
+}
+
+record ScenarioWorkspaceShellResponse(
+        String leftPanelTitle,
+        String centerPanelTitle,
+        String rightPanelTitle
+) {
+}
+
+record ScenarioTaskPreviewResponse(
+        String status,
+        String goal,
+        List<String> instructions,
+        List<String> steps
+) {
+}
+
+record ScenarioRepositoryContextResponse(
+        String status,
+        List<ScenarioRepositoryBranchResponse> branches,
+        List<ScenarioRepositoryCommitResponse> commits,
+        List<ScenarioRepositoryFileResponse> files,
+        List<ScenarioWorkspaceAnnotationResponse> annotations
+) {
+}
+
+record ScenarioRepositoryBranchResponse(
+        String name,
+        boolean current
+) {
+}
+
+record ScenarioRepositoryCommitResponse(
+        String id,
+        String summary
+) {
+}
+
+record ScenarioRepositoryFileResponse(
+        String path,
+        String status
+) {
+}
+
+record ScenarioWorkspaceAnnotationResponse(
+        String label,
+        String message
+) {
+}

--- a/src/main/java/com/example/gittrainer/scenario/api/ScenarioDetailResponseMapper.java
+++ b/src/main/java/com/example/gittrainer/scenario/api/ScenarioDetailResponseMapper.java
@@ -1,0 +1,58 @@
+package com.example.gittrainer.scenario.api;
+
+import com.example.gittrainer.scenario.application.ScenarioDetailResult;
+import com.example.gittrainer.scenario.domain.ScenarioDifficulty;
+import com.example.gittrainer.scenario.domain.ScenarioWorkspaceDetail;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScenarioDetailResponseMapper {
+
+    public ScenarioDetailResponse toResponse(ScenarioDetailResult result) {
+        ScenarioWorkspaceDetail detail = result.detail();
+        return new ScenarioDetailResponse(
+                detail.id(),
+                detail.slug(),
+                detail.title(),
+                detail.summary(),
+                toWireDifficulty(detail.difficulty()),
+                detail.tags(),
+                new ScenarioDetailMetaResponse(result.source(), result.stub()),
+                new ScenarioWorkspaceResponse(
+                        new ScenarioWorkspaceShellResponse(
+                                detail.shell().leftPanelTitle(),
+                                detail.shell().centerPanelTitle(),
+                                detail.shell().rightPanelTitle()
+                        ),
+                        new ScenarioTaskPreviewResponse(
+                                detail.task().status(),
+                                detail.task().goal(),
+                                detail.task().instructions(),
+                                detail.task().steps()
+                        ),
+                        new ScenarioRepositoryContextResponse(
+                                detail.repositoryContext().status(),
+                                detail.repositoryContext().branches().stream()
+                                        .map(branch -> new ScenarioRepositoryBranchResponse(branch.name(), branch.current()))
+                                        .toList(),
+                                detail.repositoryContext().commits().stream()
+                                        .map(commit -> new ScenarioRepositoryCommitResponse(commit.id(), commit.summary()))
+                                        .toList(),
+                                detail.repositoryContext().files().stream()
+                                        .map(file -> new ScenarioRepositoryFileResponse(file.path(), file.status()))
+                                        .toList(),
+                                detail.repositoryContext().annotations().stream()
+                                        .map(annotation -> new ScenarioWorkspaceAnnotationResponse(annotation.label(), annotation.message()))
+                                        .toList()
+                        )
+                )
+        );
+    }
+
+    private String toWireDifficulty(ScenarioDifficulty difficulty) {
+        return switch (difficulty) {
+            case BEGINNER -> "beginner";
+            case INTERMEDIATE -> "intermediate";
+        };
+    }
+}

--- a/src/main/java/com/example/gittrainer/scenario/application/LoadScenarioDetailUseCase.java
+++ b/src/main/java/com/example/gittrainer/scenario/application/LoadScenarioDetailUseCase.java
@@ -1,0 +1,23 @@
+package com.example.gittrainer.scenario.application;
+
+import com.example.gittrainer.scenario.domain.ScenarioDetailQuery;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoadScenarioDetailUseCase {
+
+    private final ScenarioDetailGateway scenarioDetailGateway;
+
+    public LoadScenarioDetailUseCase(ScenarioDetailGateway scenarioDetailGateway) {
+        this.scenarioDetailGateway = scenarioDetailGateway;
+    }
+
+    public ScenarioDetailResult load(ScenarioDetailQuery query) {
+        return new ScenarioDetailResult(
+                scenarioDetailGateway.loadScenarioDetail(query)
+                        .orElseThrow(() -> new ScenarioDetailNotFoundException(query.slug())),
+                scenarioDetailGateway.sourceName(query),
+                true
+        );
+    }
+}

--- a/src/main/java/com/example/gittrainer/scenario/application/ScenarioDetailGateway.java
+++ b/src/main/java/com/example/gittrainer/scenario/application/ScenarioDetailGateway.java
@@ -1,0 +1,13 @@
+package com.example.gittrainer.scenario.application;
+
+import com.example.gittrainer.scenario.domain.ScenarioDetailQuery;
+import com.example.gittrainer.scenario.domain.ScenarioWorkspaceDetail;
+
+import java.util.Optional;
+
+public interface ScenarioDetailGateway {
+
+    Optional<ScenarioWorkspaceDetail> loadScenarioDetail(ScenarioDetailQuery query);
+
+    String sourceName(ScenarioDetailQuery query);
+}

--- a/src/main/java/com/example/gittrainer/scenario/application/ScenarioDetailNotFoundException.java
+++ b/src/main/java/com/example/gittrainer/scenario/application/ScenarioDetailNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.gittrainer.scenario.application;
+
+public class ScenarioDetailNotFoundException extends RuntimeException {
+
+    public ScenarioDetailNotFoundException(String slug) {
+        super("Scenario detail is unavailable for slug: " + slug);
+    }
+}

--- a/src/main/java/com/example/gittrainer/scenario/application/ScenarioDetailResult.java
+++ b/src/main/java/com/example/gittrainer/scenario/application/ScenarioDetailResult.java
@@ -1,0 +1,10 @@
+package com.example.gittrainer.scenario.application;
+
+import com.example.gittrainer.scenario.domain.ScenarioWorkspaceDetail;
+
+public record ScenarioDetailResult(
+        ScenarioWorkspaceDetail detail,
+        String source,
+        boolean stub
+) {
+}

--- a/src/main/java/com/example/gittrainer/scenario/domain/ScenarioDetailQuery.java
+++ b/src/main/java/com/example/gittrainer/scenario/domain/ScenarioDetailQuery.java
@@ -1,0 +1,12 @@
+package com.example.gittrainer.scenario.domain;
+
+public record ScenarioDetailQuery(
+        String slug,
+        String source
+) {
+
+    public ScenarioDetailQuery {
+        slug = slug == null ? "" : slug.trim();
+        source = source == null || source.isBlank() ? null : source.trim();
+    }
+}

--- a/src/main/java/com/example/gittrainer/scenario/domain/ScenarioWorkspaceDetail.java
+++ b/src/main/java/com/example/gittrainer/scenario/domain/ScenarioWorkspaceDetail.java
@@ -1,0 +1,66 @@
+package com.example.gittrainer.scenario.domain;
+
+import java.util.List;
+
+public record ScenarioWorkspaceDetail(
+        String id,
+        String slug,
+        String title,
+        String summary,
+        ScenarioDifficulty difficulty,
+        List<String> tags,
+        ScenarioWorkspaceShell shell,
+        ScenarioTaskPreview task,
+        ScenarioRepositoryContext repositoryContext
+) {
+
+    public ScenarioWorkspaceDetail {
+        tags = tags == null ? List.of() : List.copyOf(tags);
+    }
+
+    public record ScenarioWorkspaceShell(
+            String leftPanelTitle,
+            String centerPanelTitle,
+            String rightPanelTitle
+    ) {
+    }
+
+    public record ScenarioTaskPreview(
+            String status,
+            String goal,
+            List<String> instructions,
+            List<String> steps
+    ) {
+        public ScenarioTaskPreview {
+            instructions = instructions == null ? List.of() : List.copyOf(instructions);
+            steps = steps == null ? List.of() : List.copyOf(steps);
+        }
+    }
+
+    public record ScenarioRepositoryContext(
+            String status,
+            List<ScenarioRepositoryBranch> branches,
+            List<ScenarioRepositoryCommit> commits,
+            List<ScenarioRepositoryFile> files,
+            List<ScenarioWorkspaceAnnotation> annotations
+    ) {
+        public ScenarioRepositoryContext {
+            branches = branches == null ? List.of() : List.copyOf(branches);
+            commits = commits == null ? List.of() : List.copyOf(commits);
+            files = files == null ? List.of() : List.copyOf(files);
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+        }
+    }
+
+    public record ScenarioRepositoryBranch(String name, boolean current) {
+    }
+
+    public record ScenarioRepositoryCommit(String id, String summary) {
+    }
+
+    public record ScenarioRepositoryFile(String path, String status) {
+    }
+
+    public record ScenarioWorkspaceAnnotation(String label, String message) {
+    }
+}

--- a/src/main/java/com/example/gittrainer/scenario/infrastructure/FixtureScenarioDetailGateway.java
+++ b/src/main/java/com/example/gittrainer/scenario/infrastructure/FixtureScenarioDetailGateway.java
@@ -1,0 +1,77 @@
+package com.example.gittrainer.scenario.infrastructure;
+
+import com.example.gittrainer.scenario.application.ScenarioDetailGateway;
+import com.example.gittrainer.scenario.domain.ScenarioDetailQuery;
+import com.example.gittrainer.scenario.domain.ScenarioSummary;
+import com.example.gittrainer.scenario.domain.ScenarioWorkspaceDetail;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class FixtureScenarioDetailGateway implements ScenarioDetailGateway {
+
+    private final ScenarioCatalogFixtureSource scenarioCatalogFixtureSource;
+
+    public FixtureScenarioDetailGateway(ScenarioCatalogFixtureSource scenarioCatalogFixtureSource) {
+        this.scenarioCatalogFixtureSource = scenarioCatalogFixtureSource;
+    }
+
+    @Override
+    public Optional<ScenarioWorkspaceDetail> loadScenarioDetail(ScenarioDetailQuery query) {
+        return resolveFixture(query).items().stream()
+                .filter(item -> item.slug().equals(query.slug()))
+                .findFirst()
+                .map(this::toStubDetail);
+    }
+
+    @Override
+    public String sourceName(ScenarioDetailQuery query) {
+        return resolveFixture(query).sourceName();
+    }
+
+    private ScenarioCatalogFixture resolveFixture(ScenarioDetailQuery query) {
+        String source = query.source();
+        if (source == null || source.isBlank() || source.equalsIgnoreCase("default")) {
+            return scenarioCatalogFixtureSource.defaultCatalog();
+        }
+        if (source.equalsIgnoreCase("empty")) {
+            return scenarioCatalogFixtureSource.emptyCatalog();
+        }
+        if (source.equalsIgnoreCase("unavailable")) {
+            return scenarioCatalogFixtureSource.unavailableCatalog();
+        }
+
+        return scenarioCatalogFixtureSource.defaultCatalog();
+    }
+
+    private ScenarioWorkspaceDetail toStubDetail(ScenarioSummary scenarioSummary) {
+        return new ScenarioWorkspaceDetail(
+                scenarioSummary.id(),
+                scenarioSummary.slug(),
+                scenarioSummary.title(),
+                scenarioSummary.summary(),
+                scenarioSummary.difficulty(),
+                scenarioSummary.tags(),
+                new ScenarioWorkspaceDetail.ScenarioWorkspaceShell(
+                        "Scenario map",
+                        "Workspace lesson",
+                        "Workspace lane"
+                ),
+                new ScenarioWorkspaceDetail.ScenarioTaskPreview(
+                        "stub",
+                        "Task content arrives in sub-issue 2.2.",
+                        List.of(),
+                        List.of()
+                ),
+                new ScenarioWorkspaceDetail.ScenarioRepositoryContext(
+                        "stub",
+                        List.of(),
+                        List.of(),
+                        List.of(),
+                        List.of()
+                )
+        );
+    }
+}

--- a/src/test/java/com/example/gittrainer/scenario/api/ScenarioCatalogControllerTest.java
+++ b/src/test/java/com/example/gittrainer/scenario/api/ScenarioCatalogControllerTest.java
@@ -136,4 +136,46 @@ class ScenarioCatalogControllerTest {
                 .andExpect(status().isServiceUnavailable())
                 .andExpect(jsonPath("$.detail").value("Catalog source is unavailable right now. Try another provider."));
     }
+
+    @Test
+    void exposesScenarioDetailStubBoundaryForKnownScenario() throws Exception {
+        mockMvc.perform(get("/api/scenarios/status-basics")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value("status-basics"))
+                .andExpect(jsonPath("$.slug").value("status-basics"))
+                .andExpect(jsonPath("$.difficulty").value("beginner"))
+                .andExpect(jsonPath("$.meta.source").value("mvp-fixture"))
+                .andExpect(jsonPath("$.meta.stub").value(true))
+                .andExpect(jsonPath("$.workspace.shell.leftPanelTitle").value("Scenario map"))
+                .andExpect(jsonPath("$.workspace.shell.centerPanelTitle").value("Workspace lesson"))
+                .andExpect(jsonPath("$.workspace.shell.rightPanelTitle").value("Workspace lane"))
+                .andExpect(jsonPath("$.workspace.task.status").value("stub"))
+                .andExpect(jsonPath("$.workspace.task.goal").value("Task content arrives in sub-issue 2.2."))
+                .andExpect(jsonPath("$.workspace.task.instructions.length()").value(0))
+                .andExpect(jsonPath("$.workspace.task.steps.length()").value(0))
+                .andExpect(jsonPath("$.workspace.repositoryContext.status").value("stub"))
+                .andExpect(jsonPath("$.workspace.repositoryContext.branches.length()").value(0))
+                .andExpect(jsonPath("$.workspace.repositoryContext.commits.length()").value(0))
+                .andExpect(jsonPath("$.workspace.repositoryContext.files.length()").value(0))
+                .andExpect(jsonPath("$.workspace.repositoryContext.annotations.length()").value(0));
+    }
+
+    @Test
+    void returnsNotFoundWhenRequestedScenarioDetailDoesNotExistInActiveSource() throws Exception {
+        mockMvc.perform(get("/api/scenarios/not-a-real-scenario")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.detail").value("Scenario detail is unavailable for slug: not-a-real-scenario"));
+    }
+
+    @Test
+    void exposesUnavailableDetailSourceThroughDetailBoundary() throws Exception {
+        mockMvc.perform(get("/api/scenarios/status-basics")
+                        .param("source", "unavailable")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.detail").value("Catalog source is unavailable right now. Try another provider."));
+    }
 }


### PR DESCRIPTION
Implements issue #139.

- adds scenario detail endpoint by slug
- returns deterministic stub workspace payload for provider integration
- covers success, not-found, and unavailable-source cases