### PR TITLE
#220 Remove unreachable provider-switch recovery copy from learner-facing flows

### DIFF
--- a/frontend/src/catalog/catalog-provider.js
+++ b/frontend/src/catalog/catalog-provider.js
@@ -24,7 +24,7 @@ export function createUnavailableFixtureCatalogProvider() {
     return {
         name: "fixture-unavailable",
         async browseCatalog() {
-            throw new Error("Catalog source is unavailable right now. Try another provider.");
+            throw new Error("Catalog source is unavailable right now. Try again in a moment.");
         }
     };
 }

--- a/frontend/src/detail/detail-provider.js
+++ b/frontend/src/detail/detail-provider.js
@@ -18,7 +18,7 @@ export function createUnavailableFixtureDetailProvider() {
     return {
         name: "fixture-unavailable",
         async loadScenarioDetail() {
-            throw new Error("Scenario detail source is unavailable right now. Try another provider.");
+            throw new Error("Scenario detail source is unavailable right now. Try again in a moment.");
         }
     };
 }

--- a/frontend/src/session/session-provider.js
+++ b/frontend/src/session/session-provider.js
@@ -138,13 +138,13 @@ export function createUnavailableFixtureSessionProvider() {
         name: "fixture-unavailable",
         async startSession() {
             throw new SessionTransportError(
-                "Session transport is unavailable right now. Try another provider.",
+                "Session transport is unavailable right now. Try again in a moment.",
                 { failureKind: "retryable", status: 503 }
             );
         },
         async submitAnswer() {
             throw new SessionTransportError(
-                "Session transport is unavailable right now. Try another provider.",
+                "Session transport is unavailable right now. Try again in a moment.",
                 { failureKind: "retryable", status: 503 }
             );
         }

--- a/frontend/src/workspace-shell/controller.js
+++ b/frontend/src/workspace-shell/controller.js
@@ -125,7 +125,10 @@ export function createCatalogWorkspaceController({
 
             state.catalog.items = [];
             state.catalog.meta = null;
-            state.catalog.error = error instanceof Error ? error.message : "Unknown catalog error";
+            state.catalog.error = toUserFacingRecoveryMessage(
+                error instanceof Error ? error.message : null,
+                "Catalog source is unavailable right now. Try again in a moment."
+            );
             state.catalog.status = "error";
         }
 
@@ -200,7 +203,10 @@ export function createCatalogWorkspaceController({
             state.detailCache[slug] = {
                 status: "error",
                 data: null,
-                error: error instanceof Error ? error.message : "Unknown scenario detail error"
+                error: toUserFacingRecoveryMessage(
+                    error instanceof Error ? error.message : null,
+                    "Scenario detail source is unavailable right now. Try again in a moment."
+                )
             };
         } finally {
             detailLoadTasks.delete(slug);
@@ -881,7 +887,7 @@ function normalizeTransportFailure(error, fallbackMessage) {
             code: error.code,
             requestedAnswerType: error.requestedAnswerType,
             supportedAnswerTypes: error.supportedAnswerTypes,
-            message: error.message || fallbackMessage,
+            message: toUserFacingRecoveryMessage(error.message, fallbackMessage),
             status: error.status
         };
     }
@@ -894,7 +900,7 @@ function normalizeTransportFailure(error, fallbackMessage) {
             code: null,
             requestedAnswerType: null,
             supportedAnswerTypes: [],
-            message: error.message || fallbackMessage,
+            message: toUserFacingRecoveryMessage(error.message, fallbackMessage),
             status: null
         };
     }
@@ -929,6 +935,11 @@ function resolveFailureKind({ failureDisposition, retryable, failureKind, status
     }
 
     return "terminal";
+}
+
+function toUserFacingRecoveryMessage(message, fallbackMessage) {
+    const resolvedMessage = normalizeOptionalValue(message) ?? fallbackMessage;
+    return resolvedMessage.replace(/Try\s+\w+\s+provider\.?$/i, "Try again in a moment.");
 }
 
 function measureNaturalNavigationWidth(navigationLane) {

--- a/frontend/src/workspace-shell/view/catalog-surfaces.js
+++ b/frontend/src/workspace-shell/view/catalog-surfaces.js
@@ -33,7 +33,7 @@ export function renderCatalogOverviewState(state) {
             return `
                 <section class="catalog-state catalog-state-empty">
                     <strong>No scenarios in this slice</strong>
-                    <p>Relax the active filters or swap providers to repopulate the scenario map.</p>
+                    <p>Relax the active filters to repopulate the scenario map.</p>
                 </section>
             `;
         default:

--- a/src/test/java/com/example/gittrainer/app/CatalogShellPageTest.java
+++ b/src/test/java/com/example/gittrainer/app/CatalogShellPageTest.java
@@ -81,6 +81,9 @@ class CatalogShellPageTest {
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("Prepared payload")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("No branch cues are available from the active detail payload.")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("Input unlocks after you open a task.")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Try again in a moment.")))
+                .andExpect(content().string(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("swap providers to repopulate the scenario map"))))
+                .andExpect(content().string(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("Try another provider."))))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("#/exercise/")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("Back to welcome")));
 


### PR DESCRIPTION
Refs #220

## Что сделано
- убрана user-facing recovery copy, которая советовала переключать provider без доступного UI action
- недостижимые provider-switch подсказки заменены на honest recovery guidance для текущего MVP flow
- сохранено текущее request-state поведение без расширения provider model

## Проверка
- ./gradlew check