### PR TITLE
#221 Make session submission counting atomic under concurrent requests

### DIFF
--- a/src/main/java/com/example/gittrainer/session/application/SessionRepository.java
+++ b/src/main/java/com/example/gittrainer/session/application/SessionRepository.java
@@ -9,4 +9,6 @@ public interface SessionRepository {
     TrainingSession save(TrainingSession session);
 
     Optional<TrainingSession> findById(String sessionId);
+
+    Optional<TrainingSession> recordSubmission(String sessionId, String submissionId);
 }

--- a/src/main/java/com/example/gittrainer/session/application/SubmitAnswerUseCase.java
+++ b/src/main/java/com/example/gittrainer/session/application/SubmitAnswerUseCase.java
@@ -40,8 +40,8 @@ public class SubmitAnswerUseCase {
         SubmittedAnswer submittedAnswer = new SubmittedAnswer(command.answerType(), command.answer());
         SubmissionOutcome outcome = submissionAnswerValidator.validate(session.scenarioSlug(), submittedAnswer);
         String submissionId = sessionIdentityGenerator.nextSubmissionId();
-        TrainingSession updatedSession = session.recordSubmission(submissionId);
-        sessionRepository.save(updatedSession);
+        TrainingSession updatedSession = sessionRepository.recordSubmission(normalizedSessionId, submissionId)
+                .orElseThrow(() -> new SessionNotFoundException(normalizedSessionId));
 
         return new SubmitAnswerResult(
                 submissionId,

--- a/src/main/java/com/example/gittrainer/session/infrastructure/InMemorySessionRepository.java
+++ b/src/main/java/com/example/gittrainer/session/infrastructure/InMemorySessionRepository.java
@@ -23,4 +23,12 @@ public class InMemorySessionRepository implements SessionRepository {
     public Optional<TrainingSession> findById(String sessionId) {
         return Optional.ofNullable(sessions.get(sessionId));
     }
+
+    @Override
+    public Optional<TrainingSession> recordSubmission(String sessionId, String submissionId) {
+        return Optional.ofNullable(sessions.computeIfPresent(
+                sessionId,
+                (ignored, existingSession) -> existingSession.recordSubmission(submissionId)
+        ));
+    }
 }

--- a/src/test/java/com/example/gittrainer/session/application/SubmitAnswerUseCaseConcurrencyTest.java
+++ b/src/test/java/com/example/gittrainer/session/application/SubmitAnswerUseCaseConcurrencyTest.java
@@ -1,0 +1,87 @@
+package com.example.gittrainer.session.application;
+
+import com.example.gittrainer.session.domain.TrainingSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class SubmitAnswerUseCaseConcurrencyTest {
+
+    @Autowired
+    private StartSessionUseCase startSessionUseCase;
+
+    @Autowired
+    private SubmitAnswerUseCase submitAnswerUseCase;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Test
+    void recordsConcurrentSubmissionsWithoutLosingAttemptIncrements() throws Exception {
+        StartSessionResult startedSession = startSessionUseCase.start(new StartSessionCommand("status-basics", null));
+        String sessionId = startedSession.session().sessionId();
+        int concurrentSubmissions = 6;
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(concurrentSubmissions);
+
+        try {
+            List<Callable<SubmitAnswerResult>> tasks = IntStream.range(0, concurrentSubmissions)
+                    .<Callable<SubmitAnswerResult>>mapToObj(ignored -> () -> {
+                        assertThat(startLatch.await(5, TimeUnit.SECONDS)).isTrue();
+                        return submitAnswerUseCase.submit(
+                                sessionId,
+                                new SubmitAnswerCommand("command_text", "git status")
+                        );
+                    })
+                    .toList();
+
+            List<Future<SubmitAnswerResult>> futures = tasks.stream()
+                    .map(executor::submit)
+                    .toList();
+
+            startLatch.countDown();
+
+            List<SubmitAnswerResult> results = futures.stream()
+                    .map(this::awaitResult)
+                    .toList();
+
+            assertThat(results)
+                    .extracting(SubmitAnswerResult::attemptNumber)
+                    .containsExactlyInAnyOrderElementsOf(IntStream.rangeClosed(1, concurrentSubmissions).boxed().toList());
+
+            Set<String> submissionIds = results.stream()
+                    .map(SubmitAnswerResult::submissionId)
+                    .collect(Collectors.toSet());
+            assertThat(submissionIds).hasSize(concurrentSubmissions);
+
+            TrainingSession persistedSession = sessionRepository.findById(sessionId).orElseThrow();
+            assertThat(persistedSession.submissionCount()).isEqualTo(concurrentSubmissions);
+            assertThat(submissionIds).contains(persistedSession.lastSubmissionId());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private SubmitAnswerResult awaitResult(Future<SubmitAnswerResult> future) {
+        try {
+            return future.get(5, TimeUnit.SECONDS);
+        } catch (Exception exception) {
+            throw new AssertionError("Concurrent submission task failed.", exception);
+        }
+    }
+}


### PR DESCRIPTION
Refs #221

## Что сделано
- session submission update переведён на атомарный repository operation
- исключён lost update между `findById` и `save`
- добавлен concurrent regression test для attempt numbering и lifecycle consistency

## Проверка
- ./gradlew check
